### PR TITLE
Add Batch functions for add, delete & synchronize products

### DIFF
--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/GoogleShopping.php
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/GoogleShopping.php
@@ -249,6 +249,36 @@ class BlueVisionTec_GoogleShoppingApi_Model_GoogleShopping extends Varien_Object
         return $result;
         
     }
+
+    /**
+     * @param array products
+     * @param integer store id
+     *
+     * @return array
+     */
+    public function productBatchDelete($products, $storeId = null) {
+    
+        $merchantId = $this->getConfig()->getConfigData('account_id',$storeId);
+        
+        $entries = array();
+
+        foreach($products as $itemId => $product) {
+            $entry = new Google_Service_ShoppingContent_ProductsCustomBatchRequestEntry();
+            $entry->setBatchId($itemId);
+            $entry->setMerchantId($merchantId);
+            $entry->setMethod('delete');
+            $entry->setProductId($product);
+            
+            $entries[] = $entry;
+        }
+        $batchReq = new Google_Service_ShoppingContent_ProductsCustomBatchRequest();
+        $batchReq->setEntries($entries);
+        
+        $result = $this->getShoppingService($storeId)->products->customBatch($batchReq);
+
+        return $result;
+        
+    }
     
     /**
      * @param Google_Service_ShoppingContent_Product product

--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/Item.php
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/Item.php
@@ -82,8 +82,7 @@ class BlueVisionTec_GoogleShoppingApi_Model_Item extends Mage_Core_Model_Abstrac
     public function insertItem(Mage_Catalog_Model_Product $product)
     {
         $this->setProduct($product);
-        $this->getServiceItem()
-            ->insert($this);
+        $this->getServiceItem();
         $this->setTypeId($this->getType()->getTypeId());
 
         return $this;

--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/MassOperations.php
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/MassOperations.php
@@ -59,40 +59,84 @@ class BlueVisionTec_GoogleShoppingApi_Model_MassOperations
      * @throws Mage_Core_Exception
      * @return BlueVisionTec_GoogleShoppingApi_Model_MassOperations
      */
-    public function addProducts($productIds, $storeId)
+    public function batchAddProducts($productIds, $storeId)
     {
         $this->_getLogger()->setStoreId($storeId);
         
         $totalAdded = 0;
+        $totalFailed = 0;
+        $itemIds = 0;
+
+        $batchInsertProducts = array();
+        $itemsCollection = array();
+
         $errors = array();
         if (is_array($productIds)) {
             foreach ($productIds as $productId) {
                 if ($this->_flag && $this->_flag->isExpired()) {
                     break;
                 }
-                try {
-                    $product = Mage::getModel('catalog/product')
-                        ->setStoreId($storeId)
-                        ->load($productId);
+                $product = Mage::getModel('catalog/product')
+                    ->setStoreId($storeId)
+                    ->load($productId);
 
-                    if ($product->getId()) {
-                        Mage::getModel('googleshoppingapi/item')
-                            ->insertItem($product)
-                            ->save();
-                        // The product was added successfully
-                        $totalAdded++;
-                    } 
-                } catch (Mage_Core_Exception $e) {
-                    $errors[] = Mage::helper('googleshoppingapi')->__('The product "%s" cannot be added to Google Content. %s', $product->getName(), $e->getMessage());
-                } catch (Exception $e) {
-                    Mage::logException($e);
-                    $errors[] = Mage::helper('googleshoppingapi')->__('The product "%s" hasn\'t been added to Google Content.', $product->getName());
-                    $errors[] = $e->getMessage();
-                }
+                if ($product->getId()) {
+
+                    $item = Mage::getModel('googleshoppingapi/item')->insertItem($product);
+
+                    $itemsCollection[$itemIds] = $item;
+                    $batchInsertProducts[$item->getStoreId()][$itemIds] = $item->getType()->convertAttributes($item->getProduct());
+
+                    // The product was added successfully
+                    $itemIds++;
+                } 
             }
             if (empty($productIds)) {
                 return $this;
             }
+
+            if(count($batchInsertProducts) > 0 ) {
+                foreach($batchInsertProducts as $storeId => $products) {
+                    try {
+                        $insertResult = Mage::getModel('googleshoppingapi/googleShopping')->productBatchInsert($products,$storeId);
+                    } catch(Exception $e) {
+                        $errors[] = "Failed to batch update for store ".$storeId.":".$e->getMessage();
+                        Mage::logException($e);
+                        Mage::log($e->getMessage());
+                    }
+                    $resEntries = array();
+                    if($insertResult) { // update expiration dates or collect errors
+                        foreach($insertResult->getEntries() as $batchEntry) {
+                            $resEntries[$batchEntry->getBatchId()] = $batchEntry;
+                        }
+                        foreach($itemsCollection as $itemId => $item) {
+                            if(isset($products[$itemId])){
+                                if(!isset($resEntries[$itemId]) || !is_a($resEntries[$itemId],'Google_Service_ShoppingContent_ProductsCustomBatchResponseEntry')) {
+                                    $errors[] = $item->getProduct()->getSku().' - '.$item->getProduct()->getTitle()." - missing response";
+                                    continue;
+                                }
+                                
+                                if($resErrors = $resEntries[$itemId]->getErrors()) {
+                                    foreach($resErrors->getErrors() as $resError) {
+                                        $totalFailed++;
+                                        $errors[] = $item->getProduct()->getSku().' - '.$item->getProduct()->getTitle()." - ".$resError->getMessage();
+                                    }
+                                } else {
+                                    
+                                    $expires = $this->convertContentDateToTimestamp(
+                                        $resEntries[$itemId]->getProduct()->getExpirationDate()
+                                    );
+                                    $item->setExpires($expires);
+                                    $item->setGcontentItemId($resEntries[$itemId]->getProduct()->getId());
+                                    $item->save();
+                                    $totalAdded++;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
         }
 
         if ($totalAdded > 0) {
@@ -102,9 +146,10 @@ class BlueVisionTec_GoogleShoppingApi_Model_MassOperations
             );
         }
 
-        if (count($errors)) {
+        if ($totalFailed > 0 || count($errors)) {
+            array_unshift($errors, Mage::helper('googleshoppingapi')->__("Cannot insert %s items.", $totalFailed));
             $this->_getLogger()->addMajor(
-                Mage::helper('googleshoppingapi')->__('Errors happened while adding products to Google Shopping.'),
+                Mage::helper('googleshoppingapi')->__('Errors happened while adding products with Google Shopping'),
                 $errors
             );
         }
@@ -113,76 +158,6 @@ class BlueVisionTec_GoogleShoppingApi_Model_MassOperations
             $this->_getLogger()->addMajor(
                 Mage::helper('googleshoppingapi')->__('Operation of adding products to Google Shopping expired.'),
                 Mage::helper('googleshoppingapi')->__('Some products may have not been added to Google Shopping bacause of expiration')
-            );
-        }
-
-        return $this;
-    }
-
-    /**
-     * Update Google Content items.
-     *
-     * @param array|BlueVisionTec_GoogleShoppingApi_Model_Resource_Item_Collection $items
-     *
-     * @throws Mage_Core_Exception
-     * @return BlueVisionTec_GoogleShoppingApi_Model_MassOperations
-     */
-    public function synchronizeItems($items)
-    {
-        $totalUpdated = 0;
-        $totalDeleted = 0;
-        $totalFailed = 0;
-        $errors = array();
-
-        $itemsCollection = $this->_getItemsCollection($items);
-
-        if ($itemsCollection) {
-            if (count($itemsCollection) < 1) {
-                return $this;
-            }
-            foreach ($itemsCollection as $item) {
-                if ($this->_flag && $this->_flag->isExpired()) {
-                    break;
-                }
-                $this->_getLogger()->setStoreId($item->getStoreId());
-                $removeInactive = $this->_getConfig()->getConfigData('autoremove_disabled',$item->getStoreId());
-				$renewNotListed = $this->_getConfig()->getConfigData('autorenew_notlisted',$item->getStoreId());
-                try {
-					if($removeInactive && ($item->getProduct()->getStatus() == Mage_Catalog_Model_Product_Status::STATUS_DISABLED || !$item->getProduct()->getStockItem()->getIsInStock() )) {
-						$item->deleteItem();
-						$item->delete();
-						$totalDeleted++;
-						Mage::log("remove inactive: ".$item->getProduct()->getSku()." - ".$item->getProduct()->getName());
-					} else {
-						$item->updateItem();
-						$item->save();
-						// The item was updated successfully
-						$totalUpdated++;
-					}
-                } catch (Mage_Core_Exception $e) {
-                    $errors[] = Mage::helper('googleshoppingapi')->__('The item "%s" cannot be updated at Google Content. %s', $item->getProduct()->getName(), $e->getMessage());
-                    $totalFailed++;
-                } catch (Exception $e) {
-                    Mage::logException($e);
-                    $errors[] = Mage::helper('googleshoppingapi')->__('The item "%s" hasn\'t been updated.', $item->getProduct()->getName());
-                    $errors[] = $e->getMessage();
-                    $totalFailed++;
-                }
-            }
-        } else {
-            return $this;
-        }
-        if($totalDeleted > 0 || $totalUpdated > 0) {
-            $this->_getLogger()->addSuccess(
-                Mage::helper('googleshoppingapi')->__('Product synchronization with Google Shopping completed') . "\n"
-                . Mage::helper('googleshoppingapi')->__('Total of %d items(s) have been deleted; total of %d items(s) have been updated.', $totalDeleted, $totalUpdated)
-            );
-        }
-        if ($totalFailed > 0 || count($errors)) {
-            array_unshift($errors, Mage::helper('googleshoppingapi')->__("Cannot update %s items.", $totalFailed));
-            $this->_getLogger()->addMajor(
-                Mage::helper('googleshoppingapi')->__('Errors happened during synchronization with Google Shopping'),
-                $errors
             );
         }
 
@@ -205,6 +180,7 @@ class BlueVisionTec_GoogleShoppingApi_Model_MassOperations
         $errors = array();
         
         $batchInsertProducts = array();
+        $batchDeleteProducts = array();
 
         $itemsCollection = $this->_getItemsCollection($items);
 
@@ -219,43 +195,173 @@ class BlueVisionTec_GoogleShoppingApi_Model_MassOperations
                 $this->_getLogger()->setStoreId($item->getStoreId());
                 $removeInactive = $this->_getConfig()->getConfigData('autoremove_disabled',$item->getStoreId());
                 $renewNotListed = $this->_getConfig()->getConfigData('autorenew_notlisted',$item->getStoreId());
-                try {
-                    if($removeInactive && ($item->getProduct()->getStatus() == Mage_Catalog_Model_Product_Status::STATUS_DISABLED || !$item->getProduct()->getStockItem()->getIsInStock() )) {
-                        // TODO: batch delete
-                        $item->deleteItem();
-                        $item->delete();
-                        $totalDeleted++;
-                        Mage::log("remove inactive: ".$item->getProduct()->getSku()." - ".$item->getProduct()->getName());
-                    } else {
-                        if(!isset($batchInsertProducts[$item->getStoreId()])) {
-                            $batchInsertProducts[$item->getStoreId()] = array();
-                        }
-                        $batchInsertProducts[$item->getStoreId()][$item->getId()] = $item->getType()->convertAttributes($item->getProduct());
+                if($removeInactive && ($item->getProduct()->getStatus() == Mage_Catalog_Model_Product_Status::STATUS_DISABLED || !$item->getProduct()->getStockItem()->getIsInStock() )) {
+                    if(!isset($batchDeleteProducts[$item->getStoreId()])) {
+                        $batchDeleteProducts[$item->getStoreId()] = array();
                     }
-                } catch (Mage_Core_Exception $e) {
-                    $errors[] = Mage::helper('googleshoppingapi')->__('The item "%s" cannot be updated at Google Content. %s', $item->getProduct()->getName(), $e->getMessage());
-                    $totalFailed++;
-                } catch (Exception $e) {
-                    // remove items which are not available on google content
-                    if($e->getCode() == "404") {
-                        $item->delete();
-                        $totalDeleted++;
-                        Mage::log("remove inactive: ".$item->getProduct()->getSku()." - ".$item->getProduct()->getName());
-                    } else {                    
+                    $batchDeleteProducts[$item->getStoreId()][$item->getId()] = $item->getGoogleShoppingItemId();
+                } else {
+                    if(!isset($batchInsertProducts[$item->getStoreId()])) {
+                        $batchInsertProducts[$item->getStoreId()] = array();
+                    }
+                    $batchInsertProducts[$item->getStoreId()][$item->getId()] = $item->getType()->convertAttributes($item->getProduct());
+                }
+            }
+
+            if(count($batchInsertProducts) > 0 ) {
+                foreach($batchInsertProducts as $storeId => $products) {
+                    try {
+                        $insertResult = Mage::getModel('googleshoppingapi/googleShopping')->productBatchInsert($products,$storeId);
+                    } catch(Exception $e) {
+                        $errors[] = "Failed to batch update for store ".$storeId.":".$e->getMessage();
                         Mage::logException($e);
-                        $errors[] = Mage::helper('googleshoppingapi')->__('The item "%s" hasn\'t been updated.', $item->getProduct()->getName());
-                        $errors[] = $e->getMessage();
-                        $totalFailed++;
+                        Mage::log($e->getMessage());
+                    }
+                    $resEntries = array();
+                    if($insertResult) { // update expiration dates or collect errors
+                        foreach($insertResult->getEntries() as $batchEntry) {
+                            $resEntries[$batchEntry->getBatchId()] = $batchEntry;
+                        }
+                        foreach($itemsCollection as $item) {
+                            if(isset($products[$item->getId()])){
+                                if(!isset($resEntries[$item->getId()]) || !is_a($resEntries[$item->getId()],'Google_Service_ShoppingContent_ProductsCustomBatchResponseEntry')) {
+                                    $errors[] = $item->getId()." - missing response";
+                                    continue;
+                                }
+                                
+                                if($resErrors = $resEntries[$item->getId()]->getErrors()) {
+                                    foreach($resErrors->getErrors() as $resError) {
+                                        $totalFailed++;
+                                        $errors[] = $item->getId()." - ".$resError->getMessage();
+                                    }
+                                } else {
+                                    
+                                    $expires = $this->convertContentDateToTimestamp(
+                                        $resEntries[$item->getId()]->getProduct()->getExpirationDate()
+                                    );
+                                    $item->setExpires($expires);
+                                    $totalUpdated++;
+                                }
+                            }
+                        }
+                        $itemsCollection->save();
+                    }
+                }
+            }
+
+            if(count($batchDeleteProducts) > 0 ) {
+                foreach($batchDeleteProducts as $storeId => $products) {
+                    try {
+                        $deleteResult = Mage::getModel('googleshoppingapi/googleShopping')->productBatchDelete($products,$storeId);
+                    } catch(Exception $e) {
+                        $errors[] = "Failed to batch delete for store ".$storeId.":".$e->getMessage();
+                        Mage::logException($e);
+                        Mage::log($e->getMessage());
+                    }
+                    $resEntries = array();
+                    if($deleteResult) { // update expiration dates or collect errors
+                        foreach($deleteResult->getEntries() as $batchEntry) {
+                            $resEntries[$batchEntry->getBatchId()] = $batchEntry;
+                        }
+                        foreach($itemsCollection as $item) {
+                            if(isset($products[$item->getId()])){
+                                if(!isset($resEntries[$item->getId()]) || !is_a($resEntries[$item->getId()],'Google_Service_ShoppingContent_ProductsCustomBatchResponseEntry')) {
+                                    $errors[] = $item->getId()." - missing response";
+                                    continue;
+                                }
+                                
+                                if($resErrors = $resEntries[$item->getId()]->getErrors()) {
+                                    foreach($resErrors->getErrors() as $resError) {
+                                        $totalFailed++;
+                                        $errors[] = $item->getId()." - ".$resError->getMessage();
+                                    }
+                                } else {
+                                    $item->delete();
+                                    $totalDeleted++;
+                                }
+                            }
+                        }
+                        $itemsCollection->save();
                     }
                 }
             }
             
-            if(count($batchInsertProducts) > 0 ) {
-                foreach($batchInsertProducts as $storeId => $products) {
+        } else {
+            return $this;
+        }
+        if($totalDeleted > 0 || $totalUpdated > 0) {
+            $this->_getLogger()->addSuccess(
+                Mage::helper('googleshoppingapi')->__('Product synchronization with Google Shopping completed.'),
+                Mage::helper('googleshoppingapi')->__('Total of %d items(s) have been deleted; total of %d items(s) have been updated.', $totalDeleted, $totalUpdated)
+            );
+        }
+        if ($totalFailed > 0 || count($errors)) {
+            array_unshift($errors, Mage::helper('googleshoppingapi')->__("Cannot update %s items.", $totalFailed));
+            $this->_getLogger()->addMajor(
+                Mage::helper('googleshoppingapi')->__('Errors happened during synchronization with Google Shopping.'),
+                $errors
+            );
+        }
+
+        return $this;
+    }
+    
+    /**
+     * Synchronize all items of a store
+     *
+     * @param int $storeId
+     *
+     * @return BlueVisionTec_GoogleShoppingApi_Model_MassOperations
+     */
+    public function synchronizeStoreItems($storeId) {
+        
+        $items = $this->_getItemsCollectionByStore($storeId);
+        $this->batchSynchronizeItems($items);
+    
+        return $this;
+    }
+
+    /**
+     * Remove Google Content items.
+     *
+     * @param array|BlueVisionTec_GoogleShoppingApi_Model_Resource_Item_Collection $items
+     * @return BlueVisionTec_GoogleShoppingApi_Model_MassOperations
+     */
+    public function batchDeleteItems($items)
+    {
+        $totalDeleted = 0;
+        $totalFailed = 0;
+        $itemsCollection = $this->_getItemsCollection($items);
+        $errors = array();
+
+        $batchDeleteProducts = array();
+
+        if ($itemsCollection) {
+            if (count($itemsCollection) < 1) {
+                return $this;
+            }
+            foreach ($itemsCollection as $item) {
+                if ($this->_flag && $this->_flag->isExpired()) {
+                    break;
+                }
+                $this->_getLogger()->setStoreId($item->getStoreId());
+                try {
+                    if(!isset($batchDeleteProducts[$item->getStoreId()])) {
+                        $batchDeleteProducts[$item->getStoreId()] = array();
+                    }
+                    $batchDeleteProducts[$item->getStoreId()][$item->getId()] = $item->getGoogleShoppingItemId();
+                } catch (Exception $e) {
+                    Mage::logException($e);
+                    $errors[] = Mage::helper('googleshoppingapi')->__('The item "%s" hasn\'t been deleted.', $item->getProduct()->getName());
+                }
+            }
+
+            if(count($batchDeleteProducts) > 0 ) {
+                foreach($batchDeleteProducts as $storeId => $products) {
                     try {
-                        $result = Mage::getModel('googleshoppingapi/googleShopping')->productBatchInsert($products,$storeId);
+                        $result = Mage::getModel('googleshoppingapi/googleShopping')->productBatchDelete($products,$storeId);
                     } catch(Exception $e) {
-                        $errors[] = "Failed to batch update for store ".$storeId.":".$e->getMessage();
+                        $errors[] = "Failed to batch delete for store ".$storeId.":".$e->getMessage();
                         Mage::logException($e);
                         Mage::log($e->getMessage());
                     }
@@ -277,93 +383,11 @@ class BlueVisionTec_GoogleShoppingApi_Model_MassOperations
                                     $errors[] = $item->getId()." - ".$resError->getMessage();
                                 }
                             } else {
-                                
-                                $expires = $this->convertContentDateToTimestamp(
-                                    $resEntries[$item->getId()]->getProduct()->getExpirationDate()
-                                );
-                                $item->setExpires($expires);
+                                $item->delete();
+                                $totalDeleted++;
                             }
                         }
                         $itemsCollection->save();
-                    }
-                }
-                
-                
-            }
-            
-        } else {
-            return $this;
-        }
-        if($totalDeleted > 0 || $totalUpdated > 0) {
-            $this->_getLogger()->addSuccess(
-                Mage::helper('googleshoppingapi')->__('Product synchronization with Google Shopping completed') . "\n"
-                . Mage::helper('googleshoppingapi')->__('Total of %d items(s) have been deleted; total of %d items(s) have been updated.', $totalDeleted, $totalUpdated)
-            );
-        }
-        if ($totalFailed > 0 || count($errors)) {
-            array_unshift($errors, Mage::helper('googleshoppingapi')->__("Cannot update %s items.", $totalFailed));
-            $this->_getLogger()->addMajor(
-                Mage::helper('googleshoppingapi')->__('Errors happened during synchronization with Google Shopping'),
-                $errors
-            );
-        }
-
-        return $this;
-    }
-    
-    /**
-     * Synchronize all items of a stroe
-     *
-     * @param int $storeId
-     *
-     * @return BlueVisionTec_GoogleShoppingApi_Model_MassOperations
-     */
-    public function synchronizeStoreItems($storeId) {
-    
-        $items = $this->_getItemsCollectionByStore($storeId);
-        $this->synchronizeItems($items);
-    
-        return $this;
-    }
-
-    /**
-     * Remove Google Content items.
-     *
-     * @param array|BlueVisionTec_GoogleShoppingApi_Model_Resource_Item_Collection $items
-     * @return BlueVisionTec_GoogleShoppingApi_Model_MassOperations
-     */
-    public function deleteItems($items)
-    {
-        $totalDeleted = 0;
-        $itemsCollection = $this->_getItemsCollection($items);
-        $errors = array();
-        if ($itemsCollection) {
-            if (count($itemsCollection) < 1) {
-                return $this;
-            }
-            foreach ($itemsCollection as $item) {
-                if ($this->_flag && $this->_flag->isExpired()) {
-                    break;
-                }
-                $this->_getLogger()->setStoreId($item->getStoreId());
-                try {
-                    $item->deleteItem()->delete();
-                    // The item was removed successfully
-                    $totalDeleted++;
-                } catch (Exception $e) {
-                    
-                    if($e->getCode() == 404){
-						$item->delete();
-						$this->_getLogger()->addNotice(
-							Mage::helper('googleshoppingapi')->__(
-								'The item "%s" was not found on GoogleContent',
-								$item->getProduct()->getName()
-							)
-						);
-						$totalDeleted++;
-                    } else {
-						Mage::logException($e);
-						$errors[] = Mage::helper('googleshoppingapi')->__('The item "%s" hasn\'t been deleted.', $item->getProduct()->getName());
                     }
                 }
             }
@@ -373,13 +397,13 @@ class BlueVisionTec_GoogleShoppingApi_Model_MassOperations
 
         if ($totalDeleted > 0) {
             $this->_getLogger()->addSuccess(
-                Mage::helper('googleshoppingapi')->__('Google Shopping item removal process succeded'),
+                Mage::helper('googleshoppingapi')->__('Google Shopping item removal process succeded.'),
                 Mage::helper('googleshoppingapi')->__('Total of %d items(s) have been removed from Google Shopping.', $totalDeleted)
             );
         }
         if (count($errors)) {
             $this->_getLogger()->addMajor(
-                Mage::helper('googleshoppingapi')->__('Errors happened while deleting items from Google Shopping'),
+                Mage::helper('googleshoppingapi')->__('Errors happened while deleting items from Google Shopping.'),
                 $errors
             );
         }

--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/Observer.php
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/Observer.php
@@ -60,7 +60,7 @@ class BlueVisionTec_GoogleShoppingApi_Model_Observer
 		$items = $this->_getItemsCollection($product);
 
 		Mage::getModel('googleshoppingapi/massOperations')
-			->synchronizeItems($items);
+			->batchSynchronizeItems($items);
 
 		return $this;
 	}
@@ -77,7 +77,7 @@ class BlueVisionTec_GoogleShoppingApi_Model_Observer
 		$items = $this->_getItemsCollection($product);
 
 		Mage::getModel('googleshoppingapi/massOperations')
-			->deleteItems($items);
+			->batchDeleteItems($items);
 
 		return $this;
 	}

--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/controllers/Adminhtml/GoogleShoppingApi/ItemsController.php
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/controllers/Adminhtml/GoogleShoppingApi/ItemsController.php
@@ -119,7 +119,7 @@ class BlueVisionTec_GoogleShoppingApi_Adminhtml_GoogleShoppingApi_ItemsControlle
             Mage::app()->setCurrentStore($storeId);
             Mage::getModel('googleshoppingapi/massOperations')
                 ->setFlag($flag)
-                ->addProducts($productIds, $storeId);
+                ->batchAddProducts($productIds, $storeId);
         } catch (Exception $e) {
             $flag->unlock();
             $this->_getLogger()->addMajor(
@@ -162,7 +162,7 @@ class BlueVisionTec_GoogleShoppingApi_Adminhtml_GoogleShoppingApi_ItemsControlle
             Mage::app()->setCurrentStore($storeId);
             Mage::getModel('googleshoppingapi/massOperations')
                 ->setFlag($flag)
-                ->deleteItems($itemIds);
+                ->batchDeleteItems($itemIds);
         } catch (Exception $e) {
             $flag->unlock();
             $this->_getLogger()->addMajor(


### PR DESCRIPTION
This builds on the batch functionality of the last commit and adds the delete and add product batching.
I only tested this with my other pull request in place for the google-api 2.0.
The performance increases about 300%.
And I can add/sync/delete about 1000 products effortlessly, with the other setup I could only add ~500 a time.

Havn't tested cron performance yet but it should go smoothly.
