### PR TITLE
Fixed autoloader of googleapi

### DIFF
--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/Block/Adminhtml/Items/Item.php
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/Block/Adminhtml/Items/Item.php
@@ -21,6 +21,7 @@ class BlueVisionTec_GoogleShoppingApi_Block_Adminhtml_Items_Item extends Mage_Ad
     {
         parent::__construct();
         $this->setId('items');
+        $this->setSaveParametersInSession(true);
         $this->setUseAjax(true);
     }
 
@@ -48,18 +49,39 @@ class BlueVisionTec_GoogleShoppingApi_Block_Adminhtml_Items_Item extends Mage_Ad
      */
     protected function _prepareColumns()
     {
+
+        $this->addColumn('id', array(
+            'header'    => $this->__('ID'),
+            'sortable'  => true,
+            'width'     => '60px',
+            'index'     => 'item_id'
+        ));
+
         $this->addColumn('name',
             array(
                 'header'    => $this->__('Product Name'),
-                'width'     => '30%',
+                'column_css_class'=> 'name',
                 'index'     => 'name',
+        ));
+
+        $this->addColumn('product_id',
+            array(
+                'header'    => $this->__('Product ID'),
+                'sortable'  => true,
+                'width'     => '60px',
+                'index'     => 'product_id',
+        ));
+        $this->addColumn('gcontent_item_id',
+            array(
+                'header'    => $this->__('Google content item ID'),
+                'index'     => 'gcontent_item_id',
         ));
 
         $this->addColumn('expires',
             array(
                 'header'    => $this->__('Expires'),
                 'type'      => 'datetime',
-                'width'     => '100px',
+                'width'     => '150px',
                 'index'     => 'expires',
         ));
 
@@ -75,7 +97,6 @@ class BlueVisionTec_GoogleShoppingApi_Block_Adminhtml_Items_Item extends Mage_Ad
     {
         $this->setMassactionIdField('item_id');
         $this->getMassactionBlock()->setFormFieldName('item');
-        $this->setNoFilterMassactionColumn(true);
 
         $this->getMassactionBlock()->addItem('delete', array(
              'label'    => $this->__('Delete'),

--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/Block/Adminhtml/Items/Product.php
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/Block/Adminhtml/Items/Product.php
@@ -23,6 +23,7 @@ class BlueVisionTec_GoogleShoppingApi_Block_Adminhtml_Items_Product
 		parent::__construct();
 		$this->setId('googleShoppingApi_selection_search_grid');
 		$this->setDefaultSort('id');
+		$this->setSaveParametersInSession(true);
 		$this->setUseAjax(true);
 	}
 
@@ -96,7 +97,7 @@ class BlueVisionTec_GoogleShoppingApi_Block_Adminhtml_Items_Product
 		$this->addColumn('type',
 			array(
 				'header'=> Mage::helper('catalog')->__('Type'),
-				'width' => '60px',
+				'width' => '150px',
 				'index' => 'type_id',
 				'type'  => 'options',
 				'options' => Mage::getSingleton('catalog/product_type')->getOptionArray(),
@@ -113,7 +114,6 @@ class BlueVisionTec_GoogleShoppingApi_Block_Adminhtml_Items_Product
 
 		$this->addColumn('sku', array(
 			'header'    => Mage::helper('sales')->__('SKU'),
-			'width'     => '80px',
 			'index'     => 'sku',
 			'column_css_class'=> 'sku'
 		));

--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/GoogleShopping.php
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/GoogleShopping.php
@@ -1,5 +1,14 @@
 <?php
-require_once Mage::getBaseDir().'/vendor/google/apiclient/src/Google/autoload.php';
+if(file_exists(Mage::getBaseDir().'/vendor/google/apiclient/src/Google/autoload.php')) { //vendor path within magento installation dir
+
+    require_once Mage::getBaseDir().'/vendor/google/apiclient/src/Google/autoload.php';
+} elseif(file_exists(Mage::getBaseDir().'/../vendor/google/apiclient/src/Google/autoload.php')) { //vendor path outside magento installation dir
+
+    set_include_path(get_include_path() . PATH_SEPARATOR . Mage::getBaseDir().'/../vendor/google/apiclient/src/Google/');
+    require_once Mage::getBaseDir().'/../vendor/google/apiclient/src/Google/autoload.php';
+} else {
+    Mage::throwException('Cannot find Google Content API autoload file');
+}
 /**
  * @category	BlueVisionTec
  * @package     BlueVisionTec_GoogleShoppingApi

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
 	],
 	"require": {
 		"magento-hackathon/magento-composer-installer": "*",
-		"google/apiclient": "*"
+		"google/apiclient": "1.1.7"
 	}
 }


### PR DESCRIPTION
and hardcode latest 1.x release of google content api

composer.json must be fixed to just include the base module, not the google api as its handled from the modules composer.json by default
