### PR TITLE
Support for Google API Client V2

### DIFF
--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/Attribute/Default.php
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/Model/Attribute/Default.php
@@ -45,7 +45,12 @@ class BlueVisionTec_GoogleShoppingApi_Model_Attribute_Default extends BlueVision
         $value = $this->getProductAttributeValue($product);
 
         if (!is_null($value)) {
-			$name = Google_Utils::camelCase($this->getName());
+            $name = (function($value) {
+                ucwords(str_replace(array('-', '_'), ' ', $value));
+                $value = str_replace(' ', '', $value);
+                $value[0] = strtolower($value[0]);
+                return $value;
+            })($this->getName());
             $shoppingProduct->offsetSet($name,$value);
         }
         

--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/etc/config.xml
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/etc/config.xml
@@ -161,6 +161,7 @@
         
         <account_type>HOSTED_OR_GOOGLE</account_type>
         <use_service_account>0</use_service_account>
+        <using_v2>0</using_v2>
         <private_key_password>notasecret</private_key_password>
         <add_store_code_to_url>1</add_store_code_to_url>
         

--- a/app/code/community/BlueVisionTec/GoogleShoppingApi/etc/system.xml
+++ b/app/code/community/BlueVisionTec/GoogleShoppingApi/etc/system.xml
@@ -175,6 +175,17 @@
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
                 </use_service_account>
+                <using_v2 translate="label">
+                    <label>Using Google API Client V2</label>
+                    <frontend_type>select</frontend_type>
+                    <source_model>adminhtml/system_config_source_yesno</source_model>
+                    <comment>Select if you are using the Google API Client V2. If you don't know the answer to this question it's probably "no". This switch is only used to hide certain options from the configuration interface.</comment>
+                    <sort_order>9</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>0</show_in_website>
+                    <show_in_store>0</show_in_store>
+                    <depends><use_service_account>1</use_service_account></depends>
+                </using_v2>
                 <client_id translate="label">
                     <label>Google Developer Project Client ID</label>
                     <frontend_type>text</frontend_type>
@@ -182,6 +193,7 @@
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
+                    <depends><using_v2>0</using_v2></depends>
                 </client_id>
                 <client_secret translate="label">
                     <label>Google Developer Project Client Secret</label>
@@ -199,6 +211,7 @@
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
+                    <depends><using_v2>0</using_v2></depends>
                 </client_email>
                 <private_key_file translate="label">
                     <label>Google Developer Project Private Key file</label>
@@ -219,7 +232,7 @@
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
-                    <depends><use_service_account>1</use_service_account></depends>
+                    <depends><use_service_account>1</use_service_account><using_v2>0</using_v2></depends>
                 </private_key_password>
                 <autorenew_notlisted translate="label">
                     <label>Renew not listed items</label>

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
 	],
 	"require": {
 		"magento-hackathon/magento-composer-installer": "*",
-		"google/apiclient": "1.1.7"
+		"google/apiclient": "^2"
+	},
+	"extra": {
+		"magento-root-dir": "root"
 	}
 }


### PR DESCRIPTION
Hello,

This PR adds support for Google API Client V2 is added when using composer to install bluevisiontec/googleshoppingapi package. Backward compatibility is maintained users with previous Google API Client versions.

When using V2 you must use the JSON key file instead of the old P12 format so make sure to update the private key file in the configuration. Also added is a configuration switch to hide the `client_id`, `client_secret` and `client_email` options because they can be inferred from the JSON key file. The goal for the future is have this done automatically (don't know how yet).

At the moment this PR is just a call for additional testers to confirm that it works under their current setup to avoid breaking current installs.

Best regards,
Ricardo Velhote